### PR TITLE
perf: ⚡️ improvement in switch expressions

### DIFF
--- a/src/main/java/jsonvalues/ImmutableJsons.java
+++ b/src/main/java/jsonvalues/ImmutableJsons.java
@@ -124,24 +124,24 @@ public final class ImmutableJsons
         ImmutableSeq newRoot = root;
         while ((elem = parser.next()) != END_ARRAY)
         {
-            switch (elem)
+            switch (elem.code)
             {
-                case VALUE_STRING:
+                case 0:
                     newRoot = newRoot.appendBack(parser.getJsString());
                     break;
-                case VALUE_NUMBER:
+                case 1:
                     newRoot = newRoot.appendBack(parser.getJsNumber());
                     break;
-                case VALUE_FALSE:
+                case 2:
                     newRoot = newRoot.appendBack(FALSE);
                     break;
-                case VALUE_TRUE:
+                case 3:
                     newRoot = newRoot.appendBack(TRUE);
                     break;
-                case VALUE_NULL:
+                case 4:
                     newRoot = newRoot.appendBack(NULL);
                     break;
-                case START_OBJECT:
+                case 5:
                     final ImmutableMap newObj = parse(this.object.emptyMap,
                                                       parser
                                                      );
@@ -149,7 +149,7 @@ public final class ImmutableJsons
                                                                     this
                     ));
                     break;
-                case START_ARRAY:
+                case 6:
                     final ImmutableSeq newSeq = parse(this.array.emptySeq,
                                                       parser
                                                      );
@@ -181,9 +181,9 @@ public final class ImmutableJsons
             JsParser.Event elem = parser.next();
             final JsPair pair;
             assert elem != null;
-            switch (elem)
+            switch (elem.code)
             {
-                case VALUE_STRING:
+                case 0:
                     pair = JsPair.of(currentPath,
                                      parser.getJsString()
                                     );
@@ -191,7 +191,7 @@ public final class ImmutableJsons
                                                                       options.elemMap.apply(pair)
                                                                      ) : newRoot;
                     break;
-                case VALUE_NUMBER:
+                case 1:
                     pair = JsPair.of(currentPath,
                                      parser.getJsNumber()
                                     );
@@ -199,15 +199,7 @@ public final class ImmutableJsons
                                                                       options.elemMap.apply(pair)
                                                                      ) : newRoot;
                     break;
-                case VALUE_TRUE:
-                    pair = JsPair.of(currentPath,
-                                     TRUE
-                                    );
-                    newRoot = (condition.test(pair)) ? newRoot.update(key,
-                                                                      options.elemMap.apply(pair)
-                                                                     ) : newRoot;
-                    break;
-                case VALUE_FALSE:
+                case 2:
                     pair = JsPair.of(currentPath,
                                      FALSE
                                     );
@@ -215,7 +207,16 @@ public final class ImmutableJsons
                                                                       options.elemMap.apply(pair)
                                                                      ) : newRoot;
                     break;
-                case VALUE_NULL:
+                case 3:
+                    pair = JsPair.of(currentPath,
+                                     TRUE
+                                    );
+                    newRoot = (condition.test(pair)) ? newRoot.update(key,
+                                                                      options.elemMap.apply(pair)
+                                                                     ) : newRoot;
+                    break;
+
+                case 4:
                     pair = JsPair.of(currentPath,
                                      NULL
                                     );
@@ -224,7 +225,7 @@ public final class ImmutableJsons
                                                                      ) : newRoot;
                     break;
 
-                case START_OBJECT:
+                case 5:
                     if (options.keyFilter.test(currentPath))
                     {
                         newRoot = newRoot.update(key,
@@ -238,7 +239,7 @@ public final class ImmutableJsons
                                                 );
                     }
                     break;
-                case START_ARRAY:
+                case 6:
                     if (options.keyFilter.test(currentPath))
                     {
                         newRoot = newRoot.update(key,
@@ -273,9 +274,9 @@ public final class ImmutableJsons
         {
             assert elem != null;
             final JsPath currentPath = path.inc();
-            switch (elem)
+            switch (elem.code)
             {
-                case VALUE_STRING:
+                case 0:
 
                     pair = JsPair.of(currentPath,
                                      parser.getJsString()
@@ -283,7 +284,7 @@ public final class ImmutableJsons
                     newRoot = condition.test(pair) ? newRoot.appendBack(options.elemMap.apply(pair)) : newRoot;
 
                     break;
-                case VALUE_NUMBER:
+                case 1:
                     pair = JsPair.of(currentPath,
                                      parser.getJsNumber()
                                     );
@@ -291,27 +292,27 @@ public final class ImmutableJsons
 
 
                     break;
-
-                case VALUE_TRUE:
+                case 2:
+                    pair = JsPair.of(currentPath,
+                                     FALSE
+                                    );
+                    newRoot = condition.test(pair) ? newRoot.appendBack(options.elemMap.apply(pair)) : newRoot;
+                    break;
+                case 3:
                     pair = JsPair.of(currentPath,
                                      TRUE
                                     );
                     newRoot = condition.test(pair) ? newRoot.appendBack(options.elemMap.apply(pair)) : newRoot;
 
                     break;
-                case VALUE_FALSE:
-                    pair = JsPair.of(currentPath,
-                                     FALSE
-                                    );
-                    newRoot = condition.test(pair) ? newRoot.appendBack(options.elemMap.apply(pair)) : newRoot;
-                    break;
-                case VALUE_NULL:
+
+                case 4:
                     pair = JsPair.of(currentPath,
                                      NULL
                                     );
                     newRoot = condition.test(pair) ? newRoot.appendBack(options.elemMap.apply(pair)) : newRoot;
                     break;
-                case START_OBJECT:
+                case 5:
                     if (options.keyFilter.test(currentPath))
                     {
                         newRoot = newRoot.appendBack(new ImmutableJsObj(parse(this.object.emptyMap,
@@ -324,7 +325,7 @@ public final class ImmutableJsons
                                                     );
                     }
                     break;
-                case START_ARRAY:
+                case 6:
                     if (options.keyFilter.test(currentPath))
                     {
                         newRoot = newRoot.appendBack(new ImmutableJsArray(parse(this.array.emptySeq,
@@ -356,34 +357,34 @@ public final class ImmutableJsons
         {
             final String key = parser.getString();
             JsParser.Event elem = parser.next();
-            switch (elem)
+            switch (elem.code)
             {
-                case VALUE_STRING:
+                case 0:
                     newRoot = newRoot.update(key,
                                              parser.getJsString()
                                             );
                     break;
-                case VALUE_NUMBER:
+                case 1:
                     newRoot = newRoot.update(key,
                                              parser.getJsNumber()
                                             );
                     break;
-                case VALUE_FALSE:
+                case 2:
                     newRoot = newRoot.update(key,
                                              FALSE
                                             );
                     break;
-                case VALUE_TRUE:
+                case 3:
                     newRoot = newRoot.update(key,
                                              TRUE
                                             );
                     break;
-                case VALUE_NULL:
+                case 4:
                     newRoot = newRoot.update(key,
                                              NULL
                                             );
                     break;
-                case START_OBJECT:
+                case 5:
                     final ImmutableMap newObj = parse(this.object.emptyMap,
                                                       parser
                                                      );
@@ -393,7 +394,7 @@ public final class ImmutableJsons
                                              )
                                             );
                     break;
-                case START_ARRAY:
+                case 6:
                     final ImmutableSeq newArr = parse(this.array.emptySeq,
                                                       parser
                                                      );
@@ -569,7 +570,7 @@ public final class ImmutableJsons
          @return an immutable five-element JsArray
          @throws UserError if an elem is a mutable Json
          */
-        //squid:S00107: static factory methods usually have more than 4 parameters, that's one their advantages precisely
+        //squid:S00107: 5 args is ok in this case
         @SuppressWarnings("squid:S00107")
         public JsArray of(final JsElem e,
                           final JsElem e1,
@@ -598,7 +599,7 @@ public final class ImmutableJsons
          @return an immutable JsArray
          @throws UserError if an elem is a mutable Json
          */
-        // squid:S00107: static factory methods usually have more than 4 parameters, that's one their advantages precisely
+        //squid:S00107: 6 args is ok in this case
         @SuppressWarnings("squid:S00107")
         public JsArray of(final JsElem e,
                           final JsElem e1,
@@ -974,7 +975,7 @@ public final class ImmutableJsons
          @return an immutable three-element JsObj
          @throws UserError if an elem is a mutable Json
          */
-        // squid:S00107: static factory methods usually have more than 4 parameters, that's one their advantages precisely
+        //squid:S00107: 6 args is ok in this case
         @SuppressWarnings("squid:S00107")
         public JsObj of(final String key1,
                         final JsElem el1,
@@ -1008,7 +1009,7 @@ public final class ImmutableJsons
          @return an immutable four-element JsObj
          @throws UserError if an elem is a mutable Json
          */
-        // squid:S00107: static factory methods usually have more than 4 parameters, that's one their advantages precisely
+        //squid:S00107: 8 args is ok in this case
         @SuppressWarnings("squid:S00107")
         public JsObj of(final String key1,
                         final JsElem el1,
@@ -1049,7 +1050,7 @@ public final class ImmutableJsons
          @return an immutable five-element JsObj
          @throws UserError if an elem is a mutable Json
          */
-        // squid:S00107: static factory methods usually have more than 4 parameters, that's one their advantages precisely
+        //squid:S00107: 10 args is ok in this case
         @SuppressWarnings("squid:S00107")
         public JsObj of(final String key1,
                         final JsElem el1,
@@ -1096,7 +1097,7 @@ public final class ImmutableJsons
          @return an immutable six-element JsObj
          @throws UserError if an elem is a mutable Json
          */
-        // squid:S00107: static factory methods usually have more than 4 parameters, that's one their advantages precisely
+        //squid:S00107: 12 args is ok in this case
         @SuppressWarnings("squid:S00107")
         public JsObj of(final String key1,
                         final JsElem el1,

--- a/src/main/java/jsonvalues/JsTokenizer.java
+++ b/src/main/java/jsonvalues/JsTokenizer.java
@@ -137,55 +137,81 @@ final class JsTokenizer implements Closeable
     enum Token
     {
         CURLYOPEN(START_OBJECT,
-                  false
+                  false,
+                  0
         ),
         SQUAREOPEN(START_ARRAY,
-                   false
+                   false,
+                   1
         ),
-        COLON(false),
-        COMMA(false),
+        COLON(false,
+              2
+        ),
+        COMMA(false,
+              3
+        ),
         STRING(VALUE_STRING,
-               true
+               true,
+               4
         ),
         NUMBER(VALUE_NUMBER,
-               true
+               true,
+               5
         ),
         TRUE(VALUE_TRUE,
-             true
+             true,
+             6
         ),
         FALSE(VALUE_FALSE,
-              true
+              true,
+              7
         ),
         NULL(VALUE_NULL,
-             true
+             true,
+             8
         ),
         CURLYCLOSE(END_OBJECT,
-                   false
+                   false,
+                   9
         ),
         SQUARECLOSE(END_ARRAY,
-                    false
+                    false,
+                    10
         ),
-        EOF(false);
-        private JsParser.Event event;
+        EOF(false,
+            11
+        );
+        private final JsParser.Event event;
         private final boolean value;
+        private final int code;
 
-        Token(JsParser.Event event,
-              boolean value
+        Token(final JsParser.Event event,
+              final boolean value,
+              final int code
              )
         {
             this.event = event;
             this.value = value;
+            this.code = code;
         }
 
-        Token(boolean value)
+        Token(final boolean value,
+              final int code
+             )
         {
             this.value = value;
+            this.code = code;
             this.event = NOTHING;
         }
 
         JsParser.Event getEvent()
         {
             return event;
+        }
+
+        public int getCode()
+        {
+            return code;
         }
 
         boolean isValue()

--- a/src/main/java/jsonvalues/MutableJsons.java
+++ b/src/main/java/jsonvalues/MutableJsons.java
@@ -126,34 +126,34 @@ public class MutableJsons
             final String key = parser.getString();
             JsParser.Event elem = parser.next();
             assert elem != null;
-            switch (elem)
+            switch (elem.code)
             {
-                case VALUE_STRING:
+                case 0:
                     root.update(key,
                                 parser.getJsString()
                                );
                     break;
-                case VALUE_NUMBER:
+                case 1:
                     root.update(key,
                                 parser.getJsNumber()
                                );
                     break;
-                case VALUE_FALSE:
+                case 2:
                     root.update(key,
                                 FALSE
                                );
                     break;
-                case VALUE_TRUE:
+                case 3:
                     root.update(key,
                                 TRUE
                                );
                     break;
-                case VALUE_NULL:
+                case 4:
                     root.update(key,
                                 NULL
                                );
                     break;
-                case START_OBJECT:
+                case 5:
                     final MutableMap obj = this.object.emptyMap();
                     parse(obj,
                           parser
@@ -164,7 +164,7 @@ public class MutableJsons
                                 )
                                );
                     break;
-                case START_ARRAY:
+                case 6:
                     final MutableSeq arr = this.array.emptySeq();
                     parse(arr,
                           parser
@@ -198,9 +198,9 @@ public class MutableJsons
             final JsPath currentPath = path.key(key);
             JsParser.Event elem = parser.next();
             assert elem != null;
-            switch (elem)
+            switch (elem.code)
             {
-                case VALUE_STRING:
+                case 0:
                     JsPair.of(currentPath,
                               parser.getJsString()
                              )
@@ -211,7 +211,7 @@ public class MutableJsons
                                     );
 
                     break;
-                case VALUE_NUMBER:
+                case 1:
                     JsPair.of(currentPath,
                               parser.getJsNumber()
                              )
@@ -222,7 +222,7 @@ public class MutableJsons
                                     );
 
                     break;
-                case VALUE_FALSE:
+                case 2:
                     JsPair.of(currentPath,
                               FALSE
                              )
@@ -234,7 +234,7 @@ public class MutableJsons
                                     );
 
                     break;
-                case VALUE_TRUE:
+                case 3:
                     JsPair.of(currentPath,
                               TRUE
                              )
@@ -246,7 +246,7 @@ public class MutableJsons
                                     );
 
                     break;
-                case VALUE_NULL:
+                case 4:
                     JsPair.of(currentPath,
                               NULL
                              )
@@ -258,7 +258,7 @@ public class MutableJsons
                                     );
 
                     break;
-                case START_OBJECT:
+                case 5:
                     if (options.keyFilter.test(currentPath))
                     {
                         final MutableMap obj = this.object.emptyMap();
@@ -274,7 +274,7 @@ public class MutableJsons
                                    );
                     }
                     break;
-                case START_ARRAY:
+                case 6:
                     if (options.keyFilter.test(currentPath))
                     {
                         final MutableSeq arr = this.array.emptySeq();
@@ -309,24 +309,24 @@ public class MutableJsons
         while ((elem = parser.next()) != END_ARRAY)
         {
             assert elem != null;
-            switch (elem)
+            switch (elem.code)
             {
-                case VALUE_STRING:
+                case 0:
                     root.appendBack(parser.getJsString());
                     break;
-                case VALUE_NUMBER:
+                case 1:
                     root.appendBack(parser.getJsNumber());
                     break;
-                case VALUE_FALSE:
+                case 2:
                     root.appendBack(FALSE);
                     break;
-                case VALUE_TRUE:
+                case 3:
                     root.appendBack(TRUE);
                     break;
-                case VALUE_NULL:
+                case 4:
                     root.appendBack(NULL);
                     break;
-                case START_OBJECT:
+                case 5:
                     final MutableMap obj = this.object.emptyMap();
                     parse(obj,
                           parser
@@ -335,7 +335,7 @@ public class MutableJsons
                                                      this
                     ));
                     break;
-                case START_ARRAY:
+                case 6:
                     final MutableSeq arr = this.array.emptySeq();
                     parse(arr,
                           parser
@@ -363,9 +363,9 @@ public class MutableJsons
         {
             assert elem != null;
             final JsPath currentPath = path.inc();
-            switch (elem)
+            switch (elem.code)
             {
-                case VALUE_STRING:
+                case 0:
                     JsPair.of(currentPath,
                               parser.getJsString()
                              )
@@ -374,7 +374,7 @@ public class MutableJsons
                                     )
                     ;
                     break;
-                case VALUE_NUMBER:
+                case 1:
                     JsPair.of(currentPath,
                               parser.getJsNumber()
                              )
@@ -382,7 +382,7 @@ public class MutableJsons
                                      p -> root.appendBack(options.elemMap.apply(p))
                                     );
                     break;
-                case VALUE_FALSE:
+                case 2:
                     JsPair.of(currentPath,
                               FALSE
                              )
@@ -391,7 +391,7 @@ public class MutableJsons
                                     )
                     ;
                     break;
-                case VALUE_TRUE:
+                case 3:
                     JsPair.of(currentPath,
                               TRUE
                              )
@@ -399,7 +399,7 @@ public class MutableJsons
                                      p -> root.appendBack(options.elemMap.apply(p))
                                     );
                     break;
-                case VALUE_NULL:
+                case 4:
                     JsPair.of(currentPath,
                               NULL
                              )
@@ -407,7 +407,7 @@ public class MutableJsons
                                      p -> root.appendBack(options.elemMap.apply(p))
                                     );
                     break;
-                case START_OBJECT:
+                case 5:
                     if (options.keyFilter.test(currentPath))
                     {
                         final MutableMap obj = this.object.emptyMap();
@@ -422,7 +422,7 @@ public class MutableJsons
                     }
                     break;
 
-                case START_ARRAY:
+                case 6:
                     if (options.keyFilter.test(currentPath))
                     {
                         final MutableSeq arr = this.array.emptySeq();
@@ -691,7 +691,7 @@ public class MutableJsons
          @return an mutable five-element JsArray
          @throws UserError if an elem is a immutable Json
          */
-        // squid:S00107: static factory methods usually have more than 4 parameters, that's one their advantages precisely
+        //squid:S00107: 5 args is ok in this case
         @SuppressWarnings("squid:S00107")
         public JsArray of(final JsElem e,
                           final JsElem e1,
@@ -720,7 +720,7 @@ public class MutableJsons
          @return an mutable JsArray
          @throws UserError if an elem is an immutable Json
          */
-        // squid:S00107: static factory methods usually have more than 4 parameters, that's one their advantages precisely
+        //squid:S00107: 6 args is ok in this case
         @SuppressWarnings("squid:S00107")
         public JsArray of(final JsElem e,
                           final JsElem e1,
@@ -1080,7 +1080,7 @@ public class MutableJsons
          @return an mutable three-element JsObj
          @throws UserError if an elem is an immutable Json
          */
-        // squid:S00107: static factory methods usually have more than 4 parameters, that's one their advantages precisely
+        //squid:S00107: 6 args is ok in this case
         @SuppressWarnings("squid:S00107")
         public JsObj of(final String key1,
                         final JsElem el1,
@@ -1114,7 +1114,7 @@ public class MutableJsons
          @return an mutable four-element JsObj
          @throws UserError if an elem is an immutable Json
          */
-        // squid:S00107: static factory methods usually have more than 4 parameters, that's one their advantages precisely
+        //squid:S00107: 8 args is ok in this case
         @SuppressWarnings("squid:S00107")
         public JsObj of(final String key1,
                         final JsElem el1,
@@ -1155,7 +1155,7 @@ public class MutableJsons
          @return an mutable five-element JsObj
          @throws UserError if an elem is an immutable Json
          */
-        // squid:S00107: static factory methods usually have more than 4 parameters, that's one their advantages precisely
+        //squid:S00107: 10 args is ok in this case
         @SuppressWarnings("squid:S00107")
         public JsObj of(final String key1,
                         final JsElem el1,
@@ -1202,7 +1202,7 @@ public class MutableJsons
          @return an mutable six-element JsObj
          @throws UserError if an elem is an immutable Json
          */
-        // squid:S00107: static factory methods usually have more than 4 parameters, that's one their advantages precisely
+        //squid:S00107: 12 args is ok in this case
         @SuppressWarnings("squid:S00107")
         public JsObj of(final String key1,
                         final JsElem el1,


### PR DESCRIPTION
when case values are contiguous (as opposed to sparse), the generated
bytecode for your various tests uses a switch table (bytecode
instruction tableswitch)

Closes: #66