### PR TITLE
V13.2.0

### DIFF
--- a/benchmarking/pom.xml
+++ b/benchmarking/pom.xml
@@ -7,7 +7,7 @@
     <packaging>jar</packaging>
     <name>json-values-benchmark-${version}</name>
     <properties>
-        <JSON-VALUES.VERSION>12.9.0</JSON-VALUES.VERSION>
+        <JSON-VALUES.VERSION>13.2.0</JSON-VALUES.VERSION>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <JMH-VERSION>1.35</JMH-VERSION>
         <JAVAX-ANNOTATION-VERSION>1.3.2</JAVAX-ANNOTATION-VERSION>
@@ -95,6 +95,12 @@
             <artifactId>junit-jupiter</artifactId>
             <version>5.8.1</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.imrafaelmerino</groupId>
+            <artifactId>json-values</artifactId>
+            <version>13.0.0</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
     <build>

--- a/benchmarking/src/main/java/jsonvalues/benchmark/Fun.java
+++ b/benchmarking/src/main/java/jsonvalues/benchmark/Fun.java
@@ -1,6 +1,7 @@
 package jsonvalues.benchmark;
 
 import jsonvalues.spec.JsObjSpec;
+import jsonvalues.spec.JsSpecs;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -21,36 +22,36 @@ public class Fun {
 
     static {
         PERSON_SPEC = JsObjSpec.of("firstName",
-                                       str(length(1,
+                                   str(length(1,
                                                   255)),
-                                       "lastName",
-                                       str(length(1,
+                                   "lastName",
+                                   str(length(1,
                                                   255)),
-                                       "age",
-                                       integer(interval(0,
+                                   "age",
+                                   integer(interval(0,
                                                         110)),
-                                       "latitude",
-                                       decimal(interval(new BigDecimal(-90),
+                                   "latitude",
+                                   decimal(interval(new BigDecimal(-90),
                                                         new BigDecimal(90)
                                                        )
                                               ),
-                                       "longitude",
-                                       decimal(interval(new BigDecimal(-180),
+                                   "longitude",
+                                   decimal(interval(new BigDecimal(-180),
                                                         new BigDecimal(180)
                                                        )
                                               ),
-                                       "fruits",
-                                       arrayOfStr(1,100),
-                                       "numbers",
-                                       arrayOfInt(1,100),
-                                       "vegetables",
-                                       arrayOfSpec(JsObjSpec.of("veggieName",
-                                                                str(length(1,
+                                   "fruits",
+                                   arrayOfStr(1,100),
+                                   "numbers",
+                                   arrayOfInt(1,100),
+                                   "vegetables",
+                                   arrayOfSpec(JsObjSpec.of("veggieName",
+                                                                    str(length(1,
                                                                            255)),
-                                                                "veggieLike",
-                                                                bool()
-                                                               )
-                                              )
+                                                                    "veggieLike",
+                                                                    bool()
+                                                                   )
+                                                      )
                                       ).withOptKeys("vegetables");
         PERSON_JSON_SCHEMA = fileContent("personSchema.json");
         PERSON_JSON = fileContent("person.json");

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,7 +62,7 @@ Improved javadoc
     - `JsObjSpecParser.of` and `JsArraySpecParser.of` instead of constructors
     - `JsReader` visibility change (is not public)
     - `JsSpec.readNextValue(JsReader)` -> `JsSpec.parse(String)`. Method used by jio-console and was changed
-      since it not necessary to create a JsReader
+      since it's not necessary to create a JsReader
     - `reduce` methods doesn't return Optional (implementation inefficient since create a lot of Optional objects)
     - `JsSerializerException` move to spec package to reduce visibility of constructors
 - Refactor internal classes and tests (clients not affected)
@@ -90,3 +90,12 @@ Improved javadoc
 - Issues:
   - https://github.com/imrafaelmerino/json-values/issues/195
 
+13.2.0
+
+
+- Previous version 13.1.0 allows named specs of any type with `JsSpecs.ofNamedSpec(name, spec)`, but
+  in the case of registering `JsObjSpec`, `JsEnum` and `JsFixedBinary` with that method instead 
+  of the builders `JsObjSpecBuilder`, `JsEnumBuilder` and `JsFixedBinaryBuilder`, we need to 
+  create the metadata object to be able to create Avro schemas with avro-spec
+
+- Proofreading typos

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -92,10 +92,13 @@ Improved javadoc
 
 13.2.0
 
-
-- Previous version 13.1.0 allows named specs of any type with `JsSpecs.ofNamedSpec(name, spec)`, but
+New features:
+  - Previous version 13.1.0 allows named specs of any type with `JsSpecs.ofNamedSpec(name, spec)`, but
   in the case of registering `JsObjSpec`, `JsEnum` and `JsFixedBinary` with that method instead 
   of the builders `JsObjSpecBuilder`, `JsEnumBuilder` and `JsFixedBinaryBuilder`, we need to 
   create the metadata object to be able to create Avro schemas with avro-spec
 
-- Proofreading typos
+    - JsEnumBuilder new overloaded build method `build(JsArray)`
+
+Doc
+    - Proofreading javadoc typos

--- a/docs/README.md
+++ b/docs/README.md
@@ -1566,16 +1566,18 @@ For Java 17 or higher:
 
 Choose the appropriate version according to your Java runtime.
 
+Find [here](./../docs/CHANGELOG.md) the releases notes.
+
+
 ## <a name="bc"><a/> Backward compatibility
 
-Please be aware that versions prior to 13.1.0 may not maintain backward compatibility, as indicated in the changelog.md
-file. This library has served as a kind of laboratory for my experimentation, and initially, backward compatibility was
+Please be aware that versions prior to 13.1.0 may not maintain backward compatibility. This library has served as a kind of laboratory for my experimentation, and initially, backward compatibility was
 not a primary concern. The focus was on creating a powerful library, and insights into necessary improvements often come
 with real-world usage.
 
 Given that the library now has a substantial user base, starting from version 13.1.0 and onwards, every effort will be
 made to ensure backward compatibility. This enhancement is aimed at providing a more stable and user-friendly
-experience, especially for a feature-rich library like json-values."
+experience, especially for a feature-rich library like json-values.
 
 ## <a name="rp"><a/> Related projects
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 <img src="./logo/package_twitter_if9bsyj4/color1/full/coverphoto/color1-white_logo_dark_background.png" alt="logo"/>
 
-[![Maven](https://img.shields.io/maven-central/v/com.github.imrafaelmerino/json-values/13.1.0)](https://search.maven.org/artifact/com.github.imrafaelmerino/json-values/13.1.0/jar)
+[![Maven](https://img.shields.io/maven-central/v/com.github.imrafaelmerino/json-values/13.2.0)](https://search.maven.org/artifact/com.github.imrafaelmerino/json-values/13.2.0/jar)
 
 “_Simplicity is a great virtue, but it requires hard work to achieve it and education to appreciate it.
 And to make matters worse: complexity sells better._”
@@ -98,7 +98,7 @@ values known to trigger bugs.
 
 **Modeling inheritance**
 
-The `jsonvalues` library simplifies the implementation of inheritance and the generation of structured data in Java.
+The json-values library simplifies the implementation of inheritance and the generation of structured data in Java.
 Let's explore an example showcasing the ease of defining object specifications, generating data, and validating against
 specifications.
 
@@ -1558,7 +1558,7 @@ For Java 17 or higher:
 <dependency>
     <groupId>com.github.imrafaelmerino</groupId>
     <artifactId>json-values</artifactId>
-    <version>13.1.0</version>
+    <version>13.2.0</version>
 </dependency>
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ And to make matters worse: complexity sells better._”
     - [Optics](#optics)
 - [Requirements](#requirements)
 - [Installation](#installation)
+- [Backward compatibility](#bc)
 - [Related projects](#rp)
 - [Sponsors](#sponsor)
 
@@ -124,8 +125,8 @@ public class ModelingInheritance {
 
     @Test
     public void test() {
-        
-        var baseSpec = 
+
+        var baseSpec =
                 JsObjSpec.of(NAME_FIELD, JsSpecs.str(),
                              TYPE_FIELD, JsSpecs.oneStringOf("mouse", "keyboard", "usb_hub"));
 
@@ -159,36 +160,36 @@ public class ModelingInheritance {
                             TYPE_FIELD, Gen.cons(JsStr.of("keyboard"))
                            )
                         .concat(baseGen);
-        
+
         var usbHubSpec =
-                JsObjSpec.of(CONNECTED_DEVICES_FIELD, 
+                JsObjSpec.of(CONNECTED_DEVICES_FIELD,
                              JsSpecs.arrayOfSpec(JsSpecs.ofNamedSpec(PERIPHERAL_FIELD))
                             )
                          .withOptKeys(CONNECTED_DEVICES_FIELD)
                          .concat(baseSpec);
 
-        var usbHubGen = 
-                JsObjGen.of(CONNECTED_DEVICES_FIELD, 
+        var usbHubGen =
+                JsObjGen.of(CONNECTED_DEVICES_FIELD,
                             JsArrayGen.biased(NamedGen.of(PERIPHERAL_FIELD), 2, 10),
                             TYPE_FIELD, Gen.cons(JsStr.of("usb_hub"))
                            )
                         .withOptKeys(CONNECTED_DEVICES_FIELD)
                         .concat(baseGen);
-        
-        var peripheralSpec = 
+
+        var peripheralSpec =
                 JsSpecs.ofNamedSpec(PERIPHERAL_FIELD,
                                     oneSpecOf(mouseSpec, keyboardSpec, usbHubSpec));
 
         var peripheralGen =
-                NamedGen.of(PERIPHERAL_FIELD, 
+                NamedGen.of(PERIPHERAL_FIELD,
                             Combinators.oneOf(mouseGen, keyboardGen, usbHubGen));
-        
+
         var parser = JsObjSpecParser.of(peripheralSpec);
-        
+
         peripheralGen.sample(10).peek(System.out::println)
                      .forEach(obj -> {
                                   System.out.println(obj.getStr(TYPE_FIELD));
-                                  
+
                                   Assertions.assertEquals(obj,
                                                           parser.parse(obj.toString())
                                                          );
@@ -197,7 +198,7 @@ public class ModelingInheritance {
                               }
                              );
     }
-    
+
 }
 
 ```
@@ -279,7 +280,8 @@ listed on [json-schema.org](https://json-schema.org/implementations.html). The r
 
 <img src="./performance_parsing_json.png" alt="parsing string comparison"/>
 
-You can find more details in the class [JsDeserializers](./../benchmarking/src/main/java/jsonvalues/benchmark/JsDeserializers.java)
+You can find more details in the
+class [JsDeserializers](./../benchmarking/src/main/java/jsonvalues/benchmark/JsDeserializers.java)
 
 Did you see that!?
 
@@ -1153,7 +1155,8 @@ catch(JsParserException e){
 ```
 
 Another compelling feature is the use of named specs, which simplifies the creation of recursive specifications. To
-implement this, start by creating a spec with `JsObjSpecBuilder` or `JsObjSpecs.ofNamedSpec(name, spec)` to give it a name . 
+implement this, start by creating a spec with `JsObjSpecBuilder` or `JsObjSpecs.ofNamedSpec(name, spec)` to give it a
+name .
 Then, refer to it using the `JsSpecs.ofNamedSpec(name)` method within its own definition.
 
 ```code
@@ -1169,7 +1172,6 @@ var spec =
 ```
 
 In this example, the spec named 'person' is referenced within its own definition.
-
 
 We can describe json-specs as:
 
@@ -1563,6 +1565,17 @@ For Java 17 or higher:
 ```
 
 Choose the appropriate version according to your Java runtime.
+
+## <a name="bc"><a/> Backward compatibility
+
+Please be aware that versions prior to 13.1.0 may not maintain backward compatibility, as indicated in the changelog.md
+file. This library has served as a kind of laboratory for my experimentation, and initially, backward compatibility was
+not a primary concern. The focus was on creating a powerful library, and insights into necessary improvements often come
+with real-world usage.
+
+Given that the library now has a substantial user base, starting from version 13.1.0 and onwards, every effort will be
+made to ensure backward compatibility. This enhancement is aimed at providing a more stable and user-friendly
+experience, especially for a feature-rich library like json-values."
 
 ## <a name="rp"><a/> Related projects
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.github.imrafaelmerino</groupId>
     <artifactId>json-values</artifactId>
     <packaging>jar</packaging>
-    <version>13.1.0</version>
+    <version>13.2.0</version>
     <name>json-values</name>
     <description>json-values is a functional Java library to work with immutable Json using persistent data
         structures.

--- a/src/main/java/jsonvalues/ArrayType.java
+++ b/src/main/java/jsonvalues/ArrayType.java
@@ -113,14 +113,32 @@ interface ArrayType<T> {
         }
 
         @Override
-        public Object copy(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+        public Object copy(Object array,
+                           int arraySize,
+                           int sourceFrom,
+                           int destinationFrom,
+                           int size
+                          ) {
             return (size > 0)
-                    ? copyNonEmpty(array, arraySize, sourceFrom, destinationFrom, size)
+                    ? copyNonEmpty(array,
+                                   arraySize,
+                                   sourceFrom,
+                                   destinationFrom,
+                                   size)
                     : new Object[arraySize];
         }
-        private static Object copyNonEmpty(Object array, int arraySize, int sourceFrom, int destinationFrom, int size) {
+        private static Object copyNonEmpty(Object array,
+                                           int arraySize,
+                                           int sourceFrom,
+                                           int destinationFrom,
+                                           int size
+                                          ) {
             final Object[] result = new Object[arraySize];
-            System.arraycopy(array, sourceFrom, result, destinationFrom, size); /* has to be near the object allocation to avoid zeroing out the array */
+            System.arraycopy(array,
+                             sourceFrom,
+                             result,
+                             destinationFrom,
+                             size); /* has to be near the object allocation to avoid zeroing out the array */
             return result;
         }
     }

--- a/src/main/java/jsonvalues/JsArray.java
+++ b/src/main/java/jsonvalues/JsArray.java
@@ -577,7 +577,7 @@ public final class JsArray implements Json<JsArray>, Iterable<JsValue> {
     }
 
     /**
-     * Returns the integral number located at the given index as an integer or a default value if it doesn't exist or
+     * Returns the integral number located at the given index as an integer or a default value if it doesn't exist, or
      * it's not an integral number, or it's an integral number but doesn't fit in an integer.
      *
      * <p>This method retrieves the JSON value at the specified index in the array and attempts to parse it as an
@@ -603,7 +603,7 @@ public final class JsArray implements Json<JsArray>, Iterable<JsValue> {
     }
 
     /**
-     * Returns the integral number located at the given index as a long or null if it doesn't exist or it's not an
+     * Returns the integral number located at the given index as a long or null if it doesn't exist, or it's not an
      * integral number, or it's an integral number but doesn't fit in a long.
      *
      * <p>This method retrieves the JSON value at the specified index in the array and attempts to parse it as an

--- a/src/main/java/jsonvalues/OpUnionJsons.java
+++ b/src/main/java/jsonvalues/OpUnionJsons.java
@@ -2,9 +2,7 @@ package jsonvalues;
 
 
 class OpUnionJsons {
-    // squid:S1452: Json<?> has only two possible types: JsObj or JsArr,
-    // squid:S00117: ARRAY_AS  should be a valid name
-    @SuppressWarnings({"squid:S1452", "squid:S00117"})
+
     static Json<?> unionAll(Json<?> a,
                             Json<?> b,
                             JsArray.TYPE ARRAY_AS

--- a/src/main/java/jsonvalues/spec/Base64.java
+++ b/src/main/java/jsonvalues/spec/Base64.java
@@ -76,7 +76,7 @@ abstract class Base64 {
 
         // Encode even 24-bits
         for (int s = 0, d = start; s < eLen; ) {
-            // Copy next three bytes into lower 24 bits of int, paying attension to sign.
+            // Copy next three bytes into lower 24 bits of int, paying attention to sign.
             int i = (sArr[s++] & 0xff) << 16 | (sArr[s++] & 0xff) << 8 | (sArr[s++] & 0xff);
 
             // Encode the int into four chars

--- a/src/main/java/jsonvalues/spec/JsArrayWriter.java
+++ b/src/main/java/jsonvalues/spec/JsArrayWriter.java
@@ -6,10 +6,10 @@ import jsonvalues.JsValue;
 import static java.util.Objects.requireNonNull;
 
 
-final class JsArrayWritter implements JsWriter.WriteObject<JsArray> {
+final class JsArrayWriter implements JsWriter.WriteObject<JsArray> {
     private final JsValueWritter valueSerializer;
 
-    JsArrayWritter(final JsValueWritter valueSerializer) {
+    JsArrayWriter(final JsValueWritter valueSerializer) {
         this.valueSerializer = valueSerializer;
     }
 

--- a/src/main/java/jsonvalues/spec/JsEnumBuilder.java
+++ b/src/main/java/jsonvalues/spec/JsEnumBuilder.java
@@ -1,6 +1,7 @@
 package jsonvalues.spec;
 
 import jsonvalues.JsArray;
+import jsonvalues.JsStr;
 
 import java.util.Arrays;
 import java.util.List;
@@ -152,6 +153,27 @@ public final class JsEnumBuilder {
                                                 "symbols of the enum.").formatted(defaultSymbol));
         var metadata = new EnumMetaData(name, nameSpace, aliases, doc, defaultSymbol);
         var enumSpec = new JsEnum(false, JsArray.ofStrs(symbols), metadata);
+        JsSpecCache.putAll(metadata.getFullName(), aliases, enumSpec);
+        return enumSpec;
+
+    }
+
+    /**
+     * Builds and returns a {@link JsEnum} specification with the specified symbols. The symbols represent the allowed
+     * values for the enum.
+     *
+     * @param symbols The symbols allowed in the enum.
+     * @return The constructed {@link JsEnum} specification.
+     * @throws IllegalArgumentException If the default symbol is specified and is not contained in the list of symbols.
+     */
+    public JsSpec build(final JsArray symbols) {
+        if(!JsSpecs.arrayOfStr().test(symbols).isEmpty())
+            throw new IllegalArgumentException("The list of symbols must be an array of strings");
+        if (defaultSymbol != null && !symbols.containsValue(JsStr.of(defaultSymbol)))
+            throw new IllegalArgumentException(("Default symbol `%s` must be contained in the list of possible " +
+                                                "symbols of the enum.").formatted(defaultSymbol));
+        var metadata = new EnumMetaData(name, nameSpace, aliases, doc, defaultSymbol);
+        var enumSpec = new JsEnum(false, symbols, metadata);
         JsSpecCache.putAll(metadata.getFullName(), aliases, enumSpec);
         return enumSpec;
 

--- a/src/main/java/jsonvalues/spec/JsEnumBuilder.java
+++ b/src/main/java/jsonvalues/spec/JsEnumBuilder.java
@@ -148,13 +148,7 @@ public final class JsEnumBuilder {
      * @throws IllegalArgumentException If the default symbol is specified and is not contained in the list of symbols.
      */
     public JsSpec build(final List<String> symbols) {
-        if (defaultSymbol != null && !symbols.contains(defaultSymbol))
-            throw new IllegalArgumentException(("Default symbol `%s` must be contained in the list of possible " +
-                                                "symbols of the enum.").formatted(defaultSymbol));
-        var metadata = new EnumMetaData(name, nameSpace, aliases, doc, defaultSymbol);
-        var enumSpec = new JsEnum(false, JsArray.ofStrs(symbols), metadata);
-        JsSpecCache.putAll(metadata.getFullName(), aliases, enumSpec);
-        return enumSpec;
+        return build(JsArray.ofStrs(symbols));
 
     }
 

--- a/src/main/java/jsonvalues/spec/JsIO.java
+++ b/src/main/java/jsonvalues/spec/JsIO.java
@@ -21,7 +21,7 @@ public final class JsIO {
     public static final JsIO INSTANCE = new JsIO();
     static final JsValueWritter valueSerializer = new JsValueWritter();
     static final JsObjWriter objSerializer = new JsObjWriter(valueSerializer);
-    static final JsArrayWritter arraySerializer = new JsArrayWritter(valueSerializer);
+    static final JsArrayWriter arraySerializer = new JsArrayWriter(valueSerializer);
 
     static {
         valueSerializer.setArraySerializer(arraySerializer);

--- a/src/main/java/jsonvalues/spec/JsObjSpecBuilder.java
+++ b/src/main/java/jsonvalues/spec/JsObjSpecBuilder.java
@@ -64,7 +64,7 @@ public final class JsObjSpecBuilder {
 
     private JsObjSpecBuilder(String name) {
         if (!isValidName.test(requireNonNull(name)))
-            throw new IllegalArgumentException(("The name of the JsObjSpec with name %s doesn't follow the " +
+            throw new IllegalArgumentException(("The name of the JsObjSpec with name `%s` doesn't follow the " +
                                                 "pattern %s"
                                                ).formatted(name,
                                                            AVRO_NAME_PATTERN));

--- a/src/main/java/jsonvalues/spec/JsSpecCache.java
+++ b/src/main/java/jsonvalues/spec/JsSpecCache.java
@@ -8,7 +8,7 @@ import static java.util.Objects.requireNonNull;
 
 final class JsSpecCache {
 
-    static Map<String, JsSpec> cache = new HashMap<>();
+    static final Map<String, JsSpec> cache = new HashMap<>();
 
     private JsSpecCache() {
     }

--- a/src/main/java/jsonvalues/spec/JsSpecs.java
+++ b/src/main/java/jsonvalues/spec/JsSpecs.java
@@ -1294,14 +1294,19 @@ public final class JsSpecs {
      * @throws IllegalArgumentException If the specified name already exists or the name is not valid
      */
     public static JsSpec ofNamedSpec(final String name, final JsSpec spec) {
-
-        if (spec instanceof JsObjSpec objSpec) {
-            JsSpecCache.put(name, JsObjSpecBuilder.withName(name).build(objSpec));
+        //builders already cache the specs, we need to create named specs with the builder
+        //to create a metadata object used by avro-spec library. It's more common to
+        //use the builder because there are a lot of metadata options not provided by this method
+        //(only the name). This is more commonly used by other kind of specs like oneOf(obspec1,objspec2)
+        if (requireNonNull(spec) instanceof JsObjSpec objSpec) {
+            var unused = JsObjSpecBuilder.withName(name).build(objSpec);
+            assert unused != null;
         } else if (spec instanceof JsEnum enumSpec) {
-            JsSpecCache.put(name, JsEnumBuilder.withName(name).build(enumSpec.symbols));
+            var unused = JsEnumBuilder.withName(name).build(enumSpec.symbols);
+            assert unused != null;
         } else if (spec instanceof JsFixedBinary fixed) {
-            JsSpecCache.put(name, JsFixedBuilder.withName(name).build(fixed.getSize()));
-
+            var unused = JsFixedBuilder.withName(name).build(fixed.getSize());
+            assert unused != null;
         } else JsSpecCache.put(name, spec);
         return new NamedSpec(name);
     }

--- a/src/main/java/jsonvalues/spec/JsSpecs.java
+++ b/src/main/java/jsonvalues/spec/JsSpecs.java
@@ -1278,7 +1278,6 @@ public final class JsSpecs {
      *
      * @param name The name of the named spec to retrieve from the cache.
      * @return A named spec with the specified name.
-     * @throws IllegalArgumentException If the specified name does not correspond to a cached named spec.
      * @see JsObjSpecBuilder
      */
     public static JsSpec ofNamedSpec(final String name) {
@@ -1286,8 +1285,24 @@ public final class JsSpecs {
     }
 
 
+    /**
+     * Creates and caches a named spec.
+     *
+     * @param name The name of the named spec.
+     * @param spec The JsSpec to be associated with the named spec.
+     * @return A named spec with the specified name.
+     * @throws IllegalArgumentException If the specified name already exists or the name is not valid
+     */
     public static JsSpec ofNamedSpec(final String name, final JsSpec spec) {
-        JsSpecCache.put(name, spec);
+
+        if (spec instanceof JsObjSpec objSpec) {
+            JsSpecCache.put(name, JsObjSpecBuilder.withName(name).build(objSpec));
+        } else if (spec instanceof JsEnum enumSpec) {
+            JsSpecCache.put(name, JsEnumBuilder.withName(name).build(enumSpec.symbols));
+        } else if (spec instanceof JsFixedBinary fixed) {
+            JsSpecCache.put(name, JsFixedBuilder.withName(name).build(fixed.getSize()));
+
+        } else JsSpecCache.put(name, spec);
         return new NamedSpec(name);
     }
 

--- a/src/main/java/jsonvalues/spec/OneOf.java
+++ b/src/main/java/jsonvalues/spec/OneOf.java
@@ -52,8 +52,8 @@ final class OneOf extends AbstractNullable implements JsSpec, AvroSpec {
     }
 
     private boolean debug(int i,JsParserException e) {
-        System.out.println("OneOf %d trie: %s".formatted(i,e.getMessage()));
-        return e != null && i >= 0;
+        System.out.printf("OneOf %d trie: %s%n", i, e.getMessage());
+        return i >= 0;
 
     }
 

--- a/src/test/java/jsonvalues/api/ModelingInheritance.java
+++ b/src/test/java/jsonvalues/api/ModelingInheritance.java
@@ -96,6 +96,7 @@ public class ModelingInheritance {
 
         peripheralGen.sample(10).peek(System.out::println)
                      .forEach(obj -> {
+                                  System.out.println(obj);
                                   System.out.println(obj.getStr(TYPE_FIELD));
 
                                   Assertions.assertEquals(obj,

--- a/src/test/java/jsonvalues/api/TestRecursiveType.java
+++ b/src/test/java/jsonvalues/api/TestRecursiveType.java
@@ -17,7 +17,7 @@ public class TestRecursiveType {
 
 
     @Test
-    public void test() {
+    public void testWithBuilder() {
 
         var spec = JsObjSpecBuilder.withName("person")
                                    .build(JsObjSpec.of("name", JsSpecs.str(),
@@ -27,6 +27,37 @@ public class TestRecursiveType {
                                                       )
                                                    .withOptKeys("father")
                                          );
+
+        var parser = JsObjSpecParser.of(spec);
+
+        var person = JsObj.of("name", JsStr.of("Rafa"),
+                              "image", JsBinary.of("a".getBytes(StandardCharsets.UTF_8)),
+                              "age", JsInt.of(40),
+                              "father", JsObj.of("name", JsStr.of("Luis"),
+                                                 "age", JsInt.of(73),
+                                                 "image", JsBinary.of("b".getBytes(StandardCharsets.UTF_8))
+                                                )
+                             );
+
+        var errors = spec.test(person);
+        Assertions.assertTrue(errors.isEmpty());
+        var parsed = parser.parse(person.toString());
+        Assertions.assertEquals(person, parsed);
+
+
+    }
+
+    @Test
+    public void testWitNamedSpecMethod() {
+
+        var spec = JsSpecs.ofNamedSpec("person_1",
+                                       JsObjSpec.of("name", JsSpecs.str(),
+                                                    "image", JsSpecs.fixedBinary(1),
+                                                    "age", JsSpecs.integer(),
+                                                    "father", JsSpecs.ofNamedSpec("person_1")
+                                                   )
+                                                .withOptKeys("father")
+                                      );
 
         var parser = JsObjSpecParser.of(spec);
 


### PR DESCRIPTION
13.2.0

New features:
  - Previous version 13.1.0 allows named specs of any type with `JsSpecs.ofNamedSpec(name, spec)`, but
  in the case of registering `JsObjSpec`, `JsEnum` and `JsFixedBinary` with that method instead 
  of the builders `JsObjSpecBuilder`, `JsEnumBuilder` and `JsFixedBinaryBuilder`, we need to 
  create the metadata object to be able to create Avro schemas with avro-spec

    - JsEnumBuilder new overloaded build method `build(JsArray)`

Doc
    - Proofreading javadoc typos